### PR TITLE
Add type assertion check

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -107,7 +107,11 @@ func (b *BQCop) insert(ctx context.Context, it *bigquery.JobIterator) *bigquery.
 
 	id := job.ID()
 	details := job.LastStatus().Statistics.Details
-	qstat := details.(*bigquery.QueryStatistics)
+	qstat, ok := details.(*bigquery.QueryStatistics)
+	if !ok {
+		return it
+	}
+
 	stat := status.Statistics
 	bqJob := &BQJob{
 		JobID:            id,


### PR DESCRIPTION
Thank you your software. Please take it in if you don't mind.

When I get stats after benchmark, I got following error so add type assertion check.

https://www.fivetran.com/blog/warehouse-benchmark
https://github.com/fivetran/benchmark

$ ./releases/bqcop_darwin_amd64/bqcop -project-id ${PROJECT_ID} -auth-json ${AUTH_JSON}
~~~~~~~
2022/02/05 22:20:03 Insert jobID: bqjob_r33738448844769f_0000017ec24ad722_1
panic: interface conversion: bigquery.Statistics is nil, not *bigquery.QueryStatistics

goroutine 1 [running]:
main.(*BQCop).insert(0xc0001a7f18, {0x471cc50, 0xc0000a2000}, 0x0)
        /Users/makoto/github/bqcop/cli.go:110 +0x365
main.(*BQCop).Do(0xc0001a7f18)
        /Users/makoto/github/bqcop/cli.go:148 +0x1d1
main.(*CLI).Run(0xc000305ac0, {0xc0000b6000, 0x5, 0x5})
        /Users/makoto/github/bqcop/cli.go:231 +0x574
main.main()
        /Users/makoto/github/bqcop/main.go:10 +0x8b